### PR TITLE
feat: add split package support

### DIFF
--- a/app/package/[repo]/[arch]/[pkgname]/page.tsx
+++ b/app/package/[repo]/[arch]/[pkgname]/page.tsx
@@ -1,8 +1,8 @@
 import {notFound} from 'next/navigation';
 
 import PackageDetailsComponent from '@/components/PackageDetails';
-import {getPackageDetails} from '@/lib/actions';
-import {PackageArch, PackageRepo} from '@/lib/types';
+import {getPackageDetails, getSplitPackages} from '@/lib/actions';
+import {BriefPackage, PackageArch, PackageRepo} from '@/lib/types';
 
 // Define the page's props, which include the dynamic route params
 type PackageDetailsPageProps = {
@@ -30,10 +30,27 @@ export default async function PackageDetailsPage({
     console.error(`Failed to fetch package details for ${pkgname}:`, error);
     notFound();
   }
+  const pkg = packageResponse.package;
+
+  let splitPackagesResponse: BriefPackage[] = [];
+  if (pkg.pkg_name === pkg.pkg_base) {
+    try {
+      splitPackagesResponse = await getSplitPackages({
+        pkgbase: pkg.pkg_base,
+        repo: repo,
+      });
+    } catch (error) {
+      console.error(`Failed to fetch split packages:`, error);
+    }
+  }
+
+  const pkgSplits = splitPackagesResponse.filter(
+    p => p.pkg_name !== pkg.pkg_base
+  );
 
   return (
     <main className="container mx-auto p-4 md:p-8">
-      <PackageDetailsComponent pkg={packageResponse.package} />
+      <PackageDetailsComponent pkg={pkg} pkgSplits={pkgSplits} />
     </main>
   );
 }

--- a/app/package/[repo]/[arch]/[pkgname]/page.tsx
+++ b/app/package/[repo]/[arch]/[pkgname]/page.tsx
@@ -1,8 +1,15 @@
 import {notFound} from 'next/navigation';
 
 import PackageDetailsComponent from '@/components/PackageDetails';
+import SplitPackageDetails from '@/components/SplitPackageDetailts';
 import {getPackageDetails, getSplitPackages} from '@/lib/actions';
-import {BriefPackage, PackageArch, PackageRepo} from '@/lib/types';
+import {FetcherError} from '@/lib/errors';
+import {
+  BriefPackage,
+  PackageArch,
+  PackageDetails,
+  PackageRepo,
+} from '@/lib/types';
 
 // Define the page's props, which include the dynamic route params
 type PackageDetailsPageProps = {
@@ -18,39 +25,94 @@ export default async function PackageDetailsPage({
 }) {
   const {arch, pkgname, repo} = await params;
 
-  let packageResponse;
-  try {
-    packageResponse = await getPackageDetails({
-      arch: arch,
-      pkgname: pkgname,
-      repo: repo,
-    });
-  } catch (error) {
-    // render Next.js's default 404 page.
-    console.error(`Failed to fetch package details for ${pkgname}:`, error);
-    notFound();
+  const packageResponse = await getPackageDetailsOrSplits({
+    arch,
+    pkgname,
+    repo,
+  });
+
+  if (packageResponse.splits) {
+    return (
+      <main className="container mx-auto p-4 md:p-8">
+        <SplitPackageDetails
+          arch={arch}
+          packages={packageResponse.splits}
+          pkgname={pkgname}
+        />
+      </main>
+    );
   }
+
   const pkg = packageResponse.package;
-
-  let splitPackagesResponse: BriefPackage[] = [];
-  if (pkg.pkg_name === pkg.pkg_base) {
-    try {
-      splitPackagesResponse = await getSplitPackages({
-        pkgbase: pkg.pkg_base,
-        repo: repo,
-      });
-    } catch (error) {
-      console.error(`Failed to fetch split packages:`, error);
-    }
-  }
-
-  const pkgSplits = splitPackagesResponse.filter(
-    p => p.pkg_name !== pkg.pkg_base
-  );
+  const pkgSplits = await getSplitPackagesForBase(pkg, repo);
 
   return (
     <main className="container mx-auto p-4 md:p-8">
       <PackageDetailsComponent pkg={pkg} pkgSplits={pkgSplits} />
     </main>
   );
+}
+
+async function getPackageDetailsOrSplits({
+  arch,
+  pkgname,
+  repo,
+}: {
+  arch: PackageArch;
+  pkgname: string;
+  repo: PackageRepo;
+}) {
+  try {
+    const packageResponse = await getPackageDetails({arch, pkgname, repo});
+    return {package: packageResponse.package};
+  } catch (error) {
+    if (error instanceof FetcherError && error.status === 404) {
+      const splits = await handleSplitPackageFallback(pkgname, repo);
+      return {splits};
+    }
+    console.error(`Failed to fetch package details for ${pkgname}:`, error);
+    notFound();
+  }
+}
+
+async function getSplitPackagesForBase(
+  pkg: PackageDetails,
+  repo: PackageRepo
+): Promise<BriefPackage[]> {
+  if (pkg.pkg_name !== pkg.pkg_base) {
+    return [];
+  }
+
+  try {
+    const splitPackagesResponse = await getSplitPackages({
+      pkgbase: pkg.pkg_base,
+      repo: repo,
+    });
+
+    return splitPackagesResponse.filter(p => p.pkg_name !== pkg.pkg_base);
+  } catch (error) {
+    console.error(`Failed to fetch split packages:`, error);
+    return [];
+  }
+}
+
+async function handleSplitPackageFallback(
+  pkgname: string,
+  repo: PackageRepo
+): Promise<BriefPackage[]> {
+  try {
+    const splitsResponse = await getSplitPackages({
+      pkgbase: pkgname,
+      repo: repo,
+    });
+
+    if (splitsResponse.length === 0) {
+      notFound();
+    }
+
+    return splitsResponse;
+  } catch (error) {
+    console.error(`Failed to fetch split packages for ${pkgname}:`, error);
+    notFound();
+  }
 }

--- a/src/components/PackageDetails.tsx
+++ b/src/components/PackageDetails.tsx
@@ -2,6 +2,7 @@
 
 import {ArrowLeft} from 'lucide-react';
 import Link from 'next/link';
+import {useState} from 'react';
 
 import {Badge} from '@/components/ui/badge';
 import {
@@ -11,15 +12,17 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import {PackageDetails} from '@/lib/types';
+import {BriefPackage, PackageDetails} from '@/lib/types';
 import {getPkgverWithoutBuildnum} from '@/lib/utils';
 
 type PackageDetailsComponentProps = {
   pkg: PackageDetails;
+  pkgSplits: BriefPackage[];
 };
 
 export default function PackageDetailsComponent({
   pkg,
+  pkgSplits,
 }: Readonly<PackageDetailsComponentProps>) {
   const sourceUrl = getArchLinuxSourceUrl(pkg);
 
@@ -69,6 +72,21 @@ export default function PackageDetailsComponent({
                 >
                   View Source Files
                 </a>
+              </DetailRow>
+            )}
+            {pkg.pkg_name === pkg.pkg_base && pkgSplits.length > 0 && (
+              <DetailRow label="Split Packages">
+                <SplitPackagesList splits={pkgSplits} />
+              </DetailRow>
+            )}
+            {pkg.pkg_name !== pkg.pkg_base && pkg.pkg_base && (
+              <DetailRow label="Base Package">
+                <Link
+                  className="text-primary hover:underline"
+                  href={`/package/${pkg.repo_name}/${pkg.pkg_arch}/${pkg.pkg_base}`}
+                >
+                  {pkg.pkg_base}
+                </Link>
               </DetailRow>
             )}
             <DetailRow label="License(s)">
@@ -179,4 +197,34 @@ function getArchLinuxSourceUrl(pkg: PackageDetails): null | string {
   }
   const arch_pkgversion = getPkgverWithoutBuildnum(pkg.pkg_version);
   return `https://gitlab.archlinux.org/archlinux/packaging/packages/${pkg.pkg_base}/-/tree/${arch_pkgversion}`;
+}
+
+// Component to display a list of split packages
+function SplitPackagesList({splits}: {splits: BriefPackage[]}) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleSplits = expanded ? splits : splits.slice(0, 5);
+  const hasMore = splits.length > 5;
+
+  return (
+    <div className="flex flex-wrap gap-1 items-center">
+      {visibleSplits.map(split => (
+        <Link
+          className="text-primary hover:underline"
+          href={`/package/${split.repo_name}/${split.pkg_arch}/${split.pkg_name}`}
+          key={split.pkg_name}
+        >
+          {split.pkg_name}
+        </Link>
+      ))}
+      {hasMore && (
+        <button
+          className="text-primary hover:underline ml-2"
+          onClick={() => setExpanded(e => !e)}
+          type="button"
+        >
+          {expanded ? 'Less...' : 'More...'}
+        </button>
+      )}
+    </div>
+  );
 }

--- a/src/components/PackageSearch.tsx
+++ b/src/components/PackageSearch.tsx
@@ -3,7 +3,7 @@
 import {AlertCircle, Loader2} from 'lucide-react';
 import {useEffect, useState} from 'react';
 
-import PackageSearchResultsTable from '@/components/PackageSearchResultsTable';
+import PackageTable from '@/components/PackageTable';
 import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert';
 import {Button} from '@/components/ui/button';
 import {
@@ -175,55 +175,53 @@ export default function PackageSearch() {
       </form>
 
       {/* Results Section */}
-      <div className="results-area">
-        {error && (
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Error</AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
 
-        {results && (
-          <div className="space-y-4">
-            <p className="text-sm text-muted-foreground">
-              Found {results.total_packages.toLocaleString()} packages. Page{' '}
-              {params.current_page} of {results.total_pages.toLocaleString()}.
+      {results && (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Found {results.total_packages.toLocaleString()} packages. Page{' '}
+            {params.current_page} of {results.total_pages.toLocaleString()}.
+          </p>
+
+          {results.packages.length > 0 ? (
+            <>
+              <PackageTable packages={results.packages} />
+              {/* Pagination Controls */}
+              <div className="flex items-center justify-end space-x-2">
+                <Button
+                  disabled={isLoading || params.current_page! <= 1}
+                  onClick={() => handleSearch(params.current_page! - 1)}
+                  size="sm"
+                  variant="outline"
+                >
+                  Previous
+                </Button>
+                <Button
+                  disabled={
+                    isLoading || params.current_page! >= results.total_pages
+                  }
+                  onClick={() => handleSearch(params.current_page! + 1)}
+                  size="sm"
+                  variant="outline"
+                >
+                  Next
+                </Button>
+              </div>
+            </>
+          ) : (
+            <p className="text-center text-muted-foreground">
+              No packages found matching your criteria.
             </p>
-
-            {results.packages.length > 0 ? (
-              <>
-                <PackageSearchResultsTable results={results} />
-                {/* Pagination Controls */}
-                <div className="flex items-center justify-end space-x-2">
-                  <Button
-                    disabled={isLoading || params.current_page! <= 1}
-                    onClick={() => handleSearch(params.current_page! - 1)}
-                    size="sm"
-                    variant="outline"
-                  >
-                    Previous
-                  </Button>
-                  <Button
-                    disabled={
-                      isLoading || params.current_page! >= results.total_pages
-                    }
-                    onClick={() => handleSearch(params.current_page! + 1)}
-                    size="sm"
-                    variant="outline"
-                  >
-                    Next
-                  </Button>
-                </div>
-              </>
-            ) : (
-              <p className="text-center text-muted-foreground">
-                No packages found matching your criteria.
-              </p>
-            )}
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/PackageTable.tsx
+++ b/src/components/PackageTable.tsx
@@ -8,14 +8,14 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import {PackageSearchResponse} from '@/lib/types';
+import {BriefPackage} from '@/lib/types';
 
 interface PackageSearchResultsTableProps {
-  results: PackageSearchResponse;
+  packages: BriefPackage[];
 }
 
-export default function PackageSearchResultsTable({
-  results,
+export default function PackageTable({
+  packages,
 }: PackageSearchResultsTableProps) {
   return (
     <div className="rounded-md border">
@@ -30,7 +30,7 @@ export default function PackageSearchResultsTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {results.packages.map(pkg => (
+          {packages.map(pkg => (
             <TableRow key={`${pkg.repo_name}-${pkg.pkg_name}-${pkg.pkg_arch}`}>
               <TableCell className="font-medium">
                 <Link

--- a/src/components/SplitPackageDetailts.tsx
+++ b/src/components/SplitPackageDetailts.tsx
@@ -1,0 +1,51 @@
+import {ArrowLeft} from 'lucide-react';
+import Link from 'next/link';
+
+import {BriefPackage} from '@/lib/types';
+
+import PackageTable from './PackageTable';
+import {Card, CardContent, CardHeader, CardTitle} from './ui/card';
+
+interface SplitPackageDetailsProps {
+  arch: string;
+  packages: BriefPackage[];
+  pkgname: string;
+}
+
+export default function SplitPackageDetails({
+  arch,
+  packages,
+  pkgname,
+}: SplitPackageDetailsProps) {
+  return (
+    <>
+      <div className="mb-4">
+        <Link
+          className="inline-flex items-center text-sm text-primary hover:underline"
+          href="/"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to Search
+        </Link>
+      </div>
+      <Card>
+        <CardHeader>
+          <div className="flex justify-between items-start">
+            <div>
+              <CardTitle>
+                Split Package Details - {pkgname} ({arch})
+              </CardTitle>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-8">
+            <div className="space-y-4">
+              <PackageTable packages={packages} />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -8,6 +8,7 @@ import {
   PackageDetailsResponse,
   PackageSearchResponse,
   PackagesSearchQueryParams,
+  SplitPackagesQueryParams,
   SplitPackagesResponse,
 } from '@/lib/types';
 
@@ -35,15 +36,16 @@ export async function getPackageDetails(
 /**
  * Retrieves the list of split packages for a given base package.
  *
- * @param repo - The repository name.
- * @param pkgbase - The base package name.
+ * @param params - The query parameters for the split packages request, including the package base and repository.
  * @returns A promise that resolves to an array of split package names.
  */
 export async function getSplitPackages(
-  repo: string,
-  pkgbase: string
+  params: SplitPackagesQueryParams
 ): Promise<SplitPackagesResponse> {
+  const {pkgbase, repo} = params;
+
   const path = `/v1/split/${encodeURIComponent(repo)}/${encodeURIComponent(pkgbase)}`;
+
   const clientHeaders = await headers();
   return fetcher<SplitPackagesResponse>(path, clientHeaders, {
     method: 'GET',

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -8,6 +8,7 @@ import {
   PackageDetailsResponse,
   PackageSearchResponse,
   PackagesSearchQueryParams,
+  SplitPackagesResponse,
 } from '@/lib/types';
 
 /**
@@ -27,6 +28,24 @@ export async function getPackageDetails(
 
   const clientHeaders = await headers();
   return fetcher<PackageDetailsResponse>(path, clientHeaders, {
+    method: 'GET',
+  });
+}
+
+/**
+ * Retrieves the list of split packages for a given base package.
+ *
+ * @param repo - The repository name.
+ * @param pkgbase - The base package name.
+ * @returns A promise that resolves to an array of split package names.
+ */
+export async function getSplitPackages(
+  repo: string,
+  pkgbase: string
+): Promise<SplitPackagesResponse> {
+  const path = `/v1/split/${encodeURIComponent(repo)}/${encodeURIComponent(pkgbase)}`;
+  const clientHeaders = await headers();
+  return fetcher<SplitPackagesResponse>(path, clientHeaders, {
     method: 'GET',
   });
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,12 @@
+import {ErrorResponse} from './types';
+
+export class FetcherError extends Error {
+  payload?: ErrorResponse;
+  status: number;
+  constructor(status: number, message: string, payload?: ErrorResponse) {
+    super(message);
+    this.name = 'FetcherError';
+    this.status = status;
+    this.payload = payload;
+  }
+}

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,6 +1,8 @@
 // thanks to https://github.com/CachyOS/builder-dashboard/blob/main/lib/fetcher.ts ;)
 import {ReadonlyHeaders} from 'next/dist/server/web/spec-extension/adapters/headers';
 
+import {FetcherError} from './errors';
+
 const EndpointURL =
   process.env.PUBLIC_ENDPOINT_URL ?? 'http://localhost:5862/api';
 
@@ -28,12 +30,31 @@ export default async function fetcher<T>(
   }).then(res => processResponse<T>(res, responseMode));
 }
 
-export function processResponse<T>(
+export async function processResponse<T>(
   response: Response,
   mode: ResponseType
 ): Promise<T> {
-  switch (mode) {
-    case 'json':
-      return response.json() as Promise<T>;
+  if (mode !== 'json') {
+    throw new Error(
+      `Unsupported response mode "${mode}" for URL "${response.url}". Status: ${response.status} ${response.statusText}.`
+    );
   }
+
+  let json;
+  try {
+    json = await response.json();
+  } catch (error) {
+    console.warn(`Failed to parse JSON response from ${response.url}:`, error);
+    throw new FetcherError(response.status, 'Invalid JSON response');
+  }
+
+  if (!response.ok) {
+    throw new FetcherError(
+      response.status,
+      response.statusText || 'Fetch error',
+      json
+    );
+  }
+
+  return json satisfies Promise<T>;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -158,4 +158,20 @@ export interface PackagesSearchQueryParams {
   search?: string;
 }
 
-export type SplitPackagesResponse = string[];
+/**
+ * Query parameters for the split packages endpoint.
+ */
+export interface SplitPackagesQueryParams {
+  /**
+   * The name of the package base.
+   * @example "openssl"
+   */
+  pkgbase: string;
+  /**
+   * The name of the repository.
+   * @example "my-stable-repo"
+   */
+  repo: PackageRepo;
+}
+
+export type SplitPackagesResponse = BriefPackage[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,3 +157,5 @@ export interface PackagesSearchQueryParams {
    */
   search?: string;
 }
+
+export type SplitPackagesResponse = string[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,14 @@ export interface BriefPackage {
 }
 
 /**
+ * Represents an error response from the API.
+ */
+export type ErrorResponse = {
+  code: number;
+  message: string;
+};
+
+/**
  * Detailed information for a specific package.
  */
 export interface PackageDetails {


### PR DESCRIPTION
See https://github.com/CachyOS/public-dashboard/issues/1#issuecomment-3085686393

Details:

The template logic for showing “Split Packages” or “Base Package” works as follows:

- **If the current package is a base package** (`pkgname == pkgbase`) and has split packages (`/split` response is not empty), it displays a list of its split packages.
- **If the current package is a split package** (`pkgname != pkgbase`), it shows a link to its base package.
- **If the package is neither a split package nor has split packages**, neither row is shown.

Example:
- https://archlinux.org/packages/extra/x86_64/vlc/
- https://archlinux.org/packages/extra/x86_64/libvlc/

EDIT:

Need to handle case similar to https://archlinux.org/packages/extra/x86_64/element.io/
Where there is no base package with the name `element.io`, so it shows a list of all the split packages instead.