### PR TITLE
chore(api): improve logging of error payload

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,7 +1,7 @@
 export class FetcherError extends Error {
-  payload?: string;
+  payload?: unknown;
   status: number;
-  constructor(status: number, message: string, payload?: string) {
+  constructor(status: number, message: string, payload?: unknown) {
     super(message);
     this.name = 'FetcherError';
     this.status = status;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,9 +1,7 @@
-import {ErrorResponse} from './types';
-
 export class FetcherError extends Error {
-  payload?: ErrorResponse;
+  payload?: string;
   status: number;
-  constructor(status: number, message: string, payload?: ErrorResponse) {
+  constructor(status: number, message: string, payload?: string) {
     super(message);
     this.name = 'FetcherError';
     this.status = status;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,10 +1,10 @@
 export class FetcherError extends Error {
-  payload?: unknown;
   status: number;
-  constructor(status: number, message: string, payload?: unknown) {
+  constructor(status: number, message: string, cause?: string, stack?: string) {
     super(message);
     this.name = 'FetcherError';
     this.status = status;
-    this.payload = payload;
+    this.cause = cause || 'Unknown cause';
+    this.stack = stack || new Error().stack;
   }
 }

--- a/src/lib/fetcher.test.ts
+++ b/src/lib/fetcher.test.ts
@@ -4,7 +4,7 @@ import {FetcherError} from './errors';
 import {processResponse, ResponseType} from './fetcher';
 
 function mockResponse({
-  jsonData = {},
+  json = {},
   jsonThrows = false,
   ok = true,
   status = 200,
@@ -16,7 +16,7 @@ function mockResponse({
       ? () => {
           throw new Error('Invalid JSON');
         }
-      : () => Promise.resolve(jsonData),
+      : () => Promise.resolve(json),
     ok,
     status,
     statusText,
@@ -26,22 +26,22 @@ function mockResponse({
 
 describe('processResponse', () => {
   test('returns JSON when response is ok', async () => {
-    const res = mockResponse({jsonData: {foo: 'bar'}});
+    const res = mockResponse({json: {foo: 'bar'}});
     const data = await processResponse<{foo: string}>(res, 'json');
     expect(data).toEqual({foo: 'bar'});
   });
 
-  test('throws FetcherError with payload when response is not ok', () => {
+  test('throws FetcherError with parsed json when response is not ok', () => {
     const res = mockResponse({
-      jsonData: {error: 'not found'},
+      json: {code: 400, message: 'not found (really)'},
       ok: false,
       status: 404,
       statusText: 'Not Found',
     });
     expect(processResponse(res, 'json')).rejects.toThrow(FetcherError);
     expect(processResponse(res, 'json')).rejects.toMatchObject({
-      payload: JSON.stringify({error: 'not found'}),
-      status: 404,
+      message: 'not found (really)',
+      status: 400,
     });
   });
 

--- a/src/lib/fetcher.test.ts
+++ b/src/lib/fetcher.test.ts
@@ -33,7 +33,7 @@ describe('processResponse', () => {
 
   test('throws FetcherError with parsed json when response is not ok', () => {
     const res = mockResponse({
-      json: {code: 400, message: 'not found (really)'},
+      json: {code: '400', message: 'not found (really)'},
       ok: false,
       status: 404,
       statusText: 'Not Found',

--- a/src/lib/fetcher.test.ts
+++ b/src/lib/fetcher.test.ts
@@ -40,7 +40,7 @@ describe('processResponse', () => {
     });
     expect(processResponse(res, 'json')).rejects.toThrow(FetcherError);
     expect(processResponse(res, 'json')).rejects.toMatchObject({
-      payload: {error: 'not found'},
+      payload: JSON.stringify({error: 'not found'}),
       status: 404,
     });
   });

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -54,7 +54,7 @@ export async function processResponse<T>(
     throw new FetcherError(
       response.status,
       response.statusText || 'Fetch error',
-      json
+      JSON.stringify(json)
     );
   }
 

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,7 +1,8 @@
 // thanks to https://github.com/CachyOS/builder-dashboard/blob/main/lib/fetcher.ts ;)
 import {ReadonlyHeaders} from 'next/dist/server/web/spec-extension/adapters/headers';
 
-import {FetcherError} from './errors';
+import {FetcherError} from '@/lib/errors';
+import {ErrorResponse} from '@/lib/types';
 
 const EndpointURL =
   process.env.PUBLIC_ENDPOINT_URL ?? 'http://localhost:5862/api';
@@ -51,10 +52,10 @@ export async function processResponse<T>(
   }
 
   if (!response.ok) {
+    const errorResponse = json as ErrorResponse;
     throw new FetcherError(
-      response.status,
-      response.statusText || 'Fetch error',
-      JSON.stringify(json)
+      errorResponse.code || response.status,
+      errorResponse.message || response.statusText || 'Fetch error'
     );
   }
 

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -54,7 +54,7 @@ export async function processResponse<T>(
   if (!response.ok) {
     const errorResponse = json as ErrorResponse;
     throw new FetcherError(
-      errorResponse.code || response.status,
+      Number(errorResponse.code) || response.status,
       errorResponse.message || response.statusText || 'Fetch error'
     );
   }

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -38,8 +38,10 @@ export async function processResponse<T>(
   mode: ResponseType
 ): Promise<T> {
   if (mode !== 'json') {
-    throw new Error(
-      `Unsupported response mode "${mode}" for URL "${response.url}". Status: ${response.status} ${response.statusText}.`
+    throw new FetcherError(
+      500,
+      `Unsupported response mode: ${mode}`,
+      `URL: "${response.url}". Status: ${response.status} ${response.statusText}.`
     );
   }
 
@@ -47,8 +49,11 @@ export async function processResponse<T>(
   try {
     json = await response.json();
   } catch (error) {
-    console.warn(`Failed to parse JSON response from ${response.url}:`, error);
-    throw new FetcherError(response.status, 'Invalid JSON response');
+    throw new FetcherError(
+      response.status,
+      'Invalid JSON response',
+      `Failed to parse JSON response from ${response.url}: ${error}`
+    );
   }
 
   if (!response.ok) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,14 +53,6 @@ export interface BriefPackage {
 }
 
 /**
- * Represents an error response from the API.
- */
-export type ErrorResponse = {
-  code: number;
-  message: string;
-};
-
-/**
  * Detailed information for a specific package.
  */
 export interface PackageDetails {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,14 @@ export interface BriefPackage {
 }
 
 /**
+ * Represents an error response from the API.
+ */
+export type ErrorResponse = {
+  code: number;
+  message: string;
+};
+
+/**
  * Detailed information for a specific package.
  */
 export interface PackageDetails {


### PR DESCRIPTION
Not sure how next.js logging works, but it doesn't handle payload field as an object. This should avoid printing useless `[Object]` for the payload in an error.


```
 ⨯ Error [FetcherError]: Internal Server Error
    at processResponse (src/lib/fetcher.ts:57:10)
  55 |       `Error response from ${response.url}: ${JSON.stringify(json)}`
  56 |     );
> 57 |     throw new FetcherError(
     |          ^
  58 |       response.status,
  59 |       response.statusText || 'Fetch error',
  60 |       json {
  payload: [Object],
  status: 500,
  digest: '3265060579'
}
```