### PR TITLE
refactor(app): put search pages in a group to share title

### DIFF
--- a/app/(search)/package/[repo]/[arch]/[pkgname]/page.tsx
+++ b/app/(search)/package/[repo]/[arch]/[pkgname]/page.tsx
@@ -12,7 +12,6 @@ import {
   PackageRepo,
 } from '@/lib/types';
 
-// Define the page's props, which include the dynamic route params
 type PackageDetailsPageProps = {
   arch: PackageArch;
   pkgname: string;

--- a/app/(search)/page.tsx
+++ b/app/(search)/page.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/card';
 
 export const metadata: Metadata = {
-  title: 'Package Search | CachyOS',
+  title: 'Package Search',
 };
 
 export default function Home() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: {
     default: 'CachyOS',
-    template: '%s | CachyOS',
+    template: 'CachyOS | %s ',
   },
 };
 


### PR DESCRIPTION
See https://nextjs.org/docs/app/api-reference/file-conventions/route-groups

I've put all search-related pages into a group so they share the same layout and title template. Before, when page.tsx (search) and layout.tsx were in the same directory, the title template wasn't applied to page.tsx.