### PR TITLE
feat(search): trim search query

### DIFF
--- a/src/components/PackageSearch.tsx
+++ b/src/components/PackageSearch.tsx
@@ -67,7 +67,10 @@ export default function PackageSearch() {
   const onFormSubmit = (searchParams: PackagesSearchQueryParams) => {
     // Reset to first page on new search to avoid out-of-bounds issue
     searchParams.current_page = 1;
-    setSearchParams(searchParams);
+    setSearchParams({
+      ...searchParams,
+      search: searchParams.search.trim(),
+    });
   };
 
   const onFormReset = () => {


### PR DESCRIPTION
Trims the search input query on submit.

Helps avoid accidental spaces: 
<img width="866" height="429" alt="image" src="https://github.com/user-attachments/assets/b5b144ef-30cd-427b-af4c-49aefcb04038" />
