### PR TITLE
fix(details): avoid preloading deps and optional deps urls

### DIFF
--- a/src/components/PackageDetails.tsx
+++ b/src/components/PackageDetails.tsx
@@ -19,6 +19,8 @@ import {
   INTL_LOCALE,
 } from '@/lib/utils';
 
+import {HoverPrefetchLink} from './HoverPrefetchLink';
+
 type PackageDetailsComponentProps = {
   pkg: PackageDetails;
   pkgSplits: BriefPackageList;
@@ -169,9 +171,11 @@ function BadgeLinkList({items}: {items: string[]}) {
     <div className="flex flex-wrap gap-1">
       {items.map(item => (
         <Badge asChild key={item} variant="secondary">
-          <Link href={{pathname: '/', query: {search: getSearch(item)}}}>
+          <HoverPrefetchLink
+            href={{pathname: '/', query: {search: getSearch(item)}}}
+          >
             {item}
-          </Link>
+          </HoverPrefetchLink>
         </Badge>
       ))}
     </div>


### PR DESCRIPTION
Can see in devtools that all the badge links on details page are preloaded due to Link having it enabled by default:

https://packages.cachyos.org/package/cachyos-extra-znver4/x86_64_v4/libreoffice-fresh

<img width="1840" height="968" alt="image" src="https://github.com/user-attachments/assets/e3f56565-51ce-4588-8392-1670c4aabf2b" />
