### PR TITLE
ci: add supercronic cache cleaner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     entrypoint: |
       sh -c '
         apk add --no-cache supercronic
-        echo "0 0 0 * * * * find /app/.next/cache/fetch-cache -type f -atime 1 -delete" > /etc/crontab
+        echo "0 0 0 * * * * find /app/.next/cache/fetch-cache -type f -atime +1 -delete" > /etc/crontab
         supercronic -debug /etc/crontab
       '
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,19 @@ services:
     ports:
       - 3000:3000
     restart: on-failure
+    volumes:
+      - cache-data:/app/.next/cache
+
+  cache-cleaner:
+    image: alpine:latest
+    volumes:
+      - cache-data:/app/.next/cache
+    entrypoint: |
+      sh -c '
+        apk add --no-cache supercronic
+        echo "0 2 * * * find /app/.next/cache/fetch-cache -type f -atime 1 -delete" > /etc/crontab
+        supercronic -debug /etc/crontab
+      '
+
+volumes:
+  cache-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     entrypoint: |
       sh -c '
         apk add --no-cache supercronic
-        echo "0 2 * * * find /app/.next/cache/fetch-cache -type f -atime 1 -delete" > /etc/crontab
+        echo "0 0 0 * * * * find /app/.next/cache/fetch-cache -type f -atime 1 -delete" > /etc/crontab
         supercronic -debug /etc/crontab
       '
 


### PR DESCRIPTION
Adds https://github.com/aptible/supercronic with an alpine container and shared volume to daily clean cache entries older than 1 day.

`supercronic` is used to have better overview and logging of the cron process within the alpine container. `-debug` flag can be removed if it's too verbose.