### PR TITLE
fix(PackageDetails): prevent long URLs from overflowing on small screens

### DIFF
--- a/src/components/PackageDetails.tsx
+++ b/src/components/PackageDetails.tsx
@@ -48,7 +48,7 @@ export default async function PackageDetailsComponent({
             <DetailRow label="Homepage">
               {pkg.pkg_url ? (
                 <a
-                  className="text-primary hover:underline"
+                  className="text-primary hover:underline break-all"
                   href={pkg.pkg_url}
                   rel="noopener noreferrer"
                   target="_blank"
@@ -111,7 +111,7 @@ export default async function PackageDetailsComponent({
             </DetailRow>
             <DetailRow label="Download Mirror">
               <a
-                className="text-primary hover:underline"
+                className="text-primary hover:underline break-all"
                 href={getDownloadMirrorUrl(pkg)}
                 target="_blank"
               >


### PR DESCRIPTION
## Description

On small screen sizes, the Download Mirror and Homepage URLs in the package details container would overflow horizontally instead of wrapping inside the card.

## Changes

Applied the `break-all` Tailwind utility to the `<a>` elements for:

- Homepage
- Download Mirror

This matches the existing pattern already used in the same component for the SHA256 sum field and the package name in `CardTitle`.

## Testing

Visual CSS-only change. No logic touched. The fix is consistent with how `break-all` is already used elsewhere in `PackageDetails.tsx`.

Fixes #67