### PR TITLE
fix: expose build version in client code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-ARG APP_VERSION=production
-ENV APP_VERSION=${APP_VERSION}
+ARG VITE_APP_VERSION=production
+ENV VITE_APP_VERSION=${VITE_APP_VERSION}
 
 RUN bun run build
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ bun server.mjs
 
 - `PORT`: Port the production server listens on (default: `3000`). Read by `server.mjs`.
 - `HOSTNAME`: Host interface the production server binds to (default: `0.0.0.0`). Read by `server.mjs`.
-- `APP_VERSION`: Injected into the dashboard `<meta>` tag. Typically set at build time via `--build-arg` or `APP_VERSION=$(git rev-parse --short HEAD)`.
+- `VITE_APP_VERSION`: Injected into the dashboard `<meta>` tag. Typically set at build time via `--build-arg` or `VITE_APP_VERSION=$(git rev-parse --short HEAD)`.
 
 #### API URL
 
@@ -98,7 +98,7 @@ To build the Docker image, run the following command from the root directory:
 docker build -t public-repo-dashboard .
 ```
 
-An optional `--build-arg APP_VERSION=$(git rev-parse --short HEAD)` can be used to include the current Git commit in the dashboard's `<meta>` tag during the build.
+An optional `--build-arg VITE_APP_VERSION=$(git rev-parse --short HEAD)` can be used to include the current Git commit in the dashboard's `<meta>` tag during the build.
 
 ### Run the Docker Container
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       args:
-        - APP_VERSION=latest
+        - VITE_APP_VERSION=latest
     container_name: public-repo-dashboard
     environment:
       # URL of the upstream JSON API this dashboard wraps.

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,7 +23,7 @@ export const Route = createRootRouteWithContext<{
       {charSet: 'utf-8'},
       {content: 'width=device-width, initial-scale=1', name: 'viewport'},
       {
-        content: import.meta.env.APP_VERSION || 'development',
+        content: import.meta.env.VITE_APP_VERSION || 'development',
         name: 'version',
       },
       {title: 'CachyOS'},


### PR DESCRIPTION
https://tanstack.com/start/latest/docs/framework/react/guide/environment-variables#client-side-context-components--client-code