### PR TITLE
feat: add Open Graph metadata

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -26,6 +26,26 @@ export const Route = createRootRouteWithContext<{
         content: import.meta.env.VITE_APP_VERSION || 'development',
         name: 'version',
       },
+      {
+        content: 'CachyOS Package Repository Dashboard',
+        property: 'og:title',
+      },
+      {
+        content: 'Search and view packages across all CachyOS repositories.',
+        property: 'og:description',
+      },
+      {
+        content: 'website',
+        property: 'og:type',
+      },
+      {
+        content: 'https://dashboard.cachyos.org/',
+        property: 'og:url',
+      },
+      {
+        content: 'https://dashboard.cachyos.org/icon.svg',
+        property: 'og:image',
+      },
       {title: 'CachyOS'},
     ],
   }),


### PR DESCRIPTION
## Summary

* Added Open Graph metadata for rich link previews
* Included title, description, type, URL, and image tags
* Reused the existing dashboard icon for `og:image`

## Validation

* Ran `bun --bun run check`
* Ran `bun --bun run build`
* Verified the generated Open Graph tags locally

Edit: Closes #105