### PR TITLE
feat: add container width toggle

### DIFF
--- a/src/components/SiteCardHeader.tsx
+++ b/src/components/SiteCardHeader.tsx
@@ -1,6 +1,7 @@
 import {Link} from '@tanstack/react-router';
 import {Package, ServerIcon} from 'lucide-react';
 import icon from '@/assets/icon.svg';
+import {ContainerToggle} from '@/components/container-toggle';
 import {ThemeToggle} from '@/components/theme-toggle';
 import {CardDescription, CardHeader, CardTitle} from '@/components/ui/card';
 
@@ -46,6 +47,7 @@ export function SiteCardHeader({
               <span className="sr-only sm:not-sr-only">Packages</span>
             </Link>
           )}
+          <ContainerToggle />
           <ThemeToggle />
         </div>
       </div>

--- a/src/components/container-toggle.tsx
+++ b/src/components/container-toggle.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import {Maximize2, Minimize2} from 'lucide-react';
+import {useState} from 'react';
+
+import {Button} from '@/components/ui/button';
+
+export function ContainerToggle() {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleContainer = () => {
+    document.querySelector('main')?.classList.toggle('container');
+    setExpanded(current => !current);
+  };
+
+  const label = expanded ? 'Collapse content width' : 'Expand content width';
+
+  return (
+    <Button
+      aria-label={label}
+      aria-pressed={expanded}
+      onClick={toggleContainer}
+      size="icon"
+      title={label}
+      variant="ghost"
+    >
+      {expanded ? (
+        <Minimize2 className="size-5" />
+      ) : (
+        <Maximize2 className="size-5" />
+      )}
+      <span className="sr-only">{label}</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

* Added an expand/collapse button next to the theme toggle
* Toggle the `container` class on the main element
* Added accessible labels and a visual state indicator

## Validation

* Ran `bun --bun run check`
* Ran `bun --bun run test`
* Ran `bun --bun run build`
* Verified the toggle on the package search and mirrors pages

Closes #103

<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/e891a811-0186-4896-b7ca-e6f34f71c9ac" />
<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/2f81cad3-5df9-4a92-be70-6c08b4efcf03" />
