### PR TITLE
feat: search autofocus on empty and submit on click

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The web dashboard for the CachyOS repositories provides a user-friendly interfac
     bun --bun run dev
     ```
 
+To be able to use real API from local environment create an `.env` file and add `VITE_ENDPOINT_URL=https://dashboard.cachyos.org/api` there.
+
 The application will be available at [http://localhost:3000](http://localhost:3000).
 
 ### Building for Production

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -82,7 +82,11 @@ function Autocomplete({
               key={suggestion}
               onClick={() =>
                 handleInputChange({
-                  target: {name: props.name || '', value: suggestion},
+                  target: {
+                    name: props.name || '',
+                    type: 'click',
+                    value: suggestion,
+                  },
                 } as React.ChangeEvent<HTMLInputElement>)
               }
             >

--- a/src/components/PackageSearchForm.tsx
+++ b/src/components/PackageSearchForm.tsx
@@ -59,10 +59,13 @@ export default function PackageSearchForm({
   const onInputChange = (
     e:
       | React.ChangeEvent<HTMLInputElement>
-      | {target: {name: string; value: string}}
+      | {target: {name: string; type?: string; value: string}}
   ) => {
-    const {name, value} = e.target;
+    const {name, type, value} = e.target;
     setParams(prev => ({...prev, [name]: value}));
+    if (type == 'click') {
+      onSubmit({...params, [name]: value});
+    }
   };
 
   const handleSelectionChange = (name: 'arch' | 'repo', value: string) => {
@@ -94,6 +97,7 @@ export default function PackageSearchForm({
           <Label htmlFor="search">Package Name/Description</Label>
           <Autocomplete
             aria-label="Search input"
+            autoFocus={params.search.trim() == ''}
             id="search"
             name="search"
             onChange={onInputChange}

--- a/src/components/PackageSearchForm.tsx
+++ b/src/components/PackageSearchForm.tsx
@@ -63,7 +63,7 @@ export default function PackageSearchForm({
   ) => {
     const {name, type, value} = e.target;
     setParams(prev => ({...prev, [name]: value}));
-    if (type == 'click') {
+    if (type === 'click') {
       onSubmit({...params, [name]: value});
     }
   };

--- a/src/components/PackageSearchForm.tsx
+++ b/src/components/PackageSearchForm.tsx
@@ -97,7 +97,7 @@ export default function PackageSearchForm({
           <Label htmlFor="search">Package Name/Description</Label>
           <Autocomplete
             aria-label="Search input"
-            autoFocus={params.search.trim() == ''}
+            autoFocus={params.search.trim() === ''}
             id="search"
             name="search"
             onChange={onInputChange}


### PR DESCRIPTION
Closes #122

It auto-focuses now when input is empty. And when using mouse to click a suggestion from list it submits the search form.